### PR TITLE
Fix docs linking bug

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -412,11 +412,11 @@ if (try post.fetchPostAuthor(&pool, allocator)) |author| {
 
 ### Explore Advanced Features
 
-- **Complex Queries**: [QUERY.md](docs/QUERY.md)
-- **Transactions**: [TRANSACTION.md](docs/TRANSACTION.md)
-- **Relationships**: [RELATIONSHIPS.md](docs/RELATIONSHIPS.md)
-- **Field Types**: [SCHEMA.md](docs/SCHEMA.md)
-- **Migrations**: [MIGRATIONS.md](docs/MIGRATIONS.md)
+- **Complex Queries**: [QUERY.md](/QUERY.md)
+- **Transactions**: [TRANSACTION.md](/TRANSACTION.md)
+- **Relationships**: [RELATIONSHIPS.md](/RELATIONSHIPS.md)
+- **Field Types**: [SCHEMA.md](/SCHEMA.md)
+- **Migrations**: [MIGRATIONS.md](/MIGRATIONS.md)
 
 ## Common Issues
 


### PR DESCRIPTION
This PR fixes incorrect or broken relative links in the project documentation.
docs/GETTING_STARTED.md were pointing to the wrong path or inconsistent paths (mix of docs/... and root /... references).