### PR TITLE
Fix: Correct documentation links (post-merge cleanup)

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -412,11 +412,11 @@ if (try post.fetchPostAuthor(&pool, allocator)) |author| {
 
 ### Explore Advanced Features
 
-- **Complex Queries**: [QUERY.md](/QUERY.md)
-- **Transactions**: [TRANSACTION.md](/TRANSACTION.md)
-- **Relationships**: [RELATIONSHIPS.md](/RELATIONSHIPS.md)
-- **Field Types**: [SCHEMA.md](/SCHEMA.md)
-- **Migrations**: [MIGRATIONS.md](/MIGRATIONS.md)
+- **Complex Queries**: [QUERY.md](QUERY.md)
+- **Transactions**: [TRANSACTION.md](TRANSACTION.md)
+- **Relationships**: [RELATIONSHIPS.md](RELATIONSHIPS.md)
+- **Field Types**: [SCHEMA.md](SCHEMA.md)
+- **Migrations**: [MIGRATIONS.md](MIGRATIONS.md)
 
 ## Common Issues
 


### PR DESCRIPTION
I noticed the previous PR was merged with the wrong relative paths.
This PR corrects all links to the proper format so navigation works as intended.