### PR TITLE
feat: add reset function to clear all query clauses and enable builde…

### DIFF
--- a/src/query.zig
+++ b/src/query.zig
@@ -158,6 +158,21 @@ pub fn QueryBuilder(comptime T: type, comptime K: type, comptime FE: type) type 
             self.arena.deinit();
         }
 
+        /// Reset the query - clear all clauses, this makes the query builder reusable
+        ///
+        /// Example:
+        /// ```zig
+        /// .reset()
+        /// ```
+        pub fn reset(self: *Self) void {
+            self.where_clauses.clearAndFree(self.arena.allocator());
+            self.select_clauses.clearAndFree(self.arena.allocator());
+            self.order_clauses.clearAndFree(self.arena.allocator());
+            self.group_clauses.clearAndFree(self.arena.allocator());
+            self.having_clauses.clearAndFree(self.arena.allocator());
+            self.join_clauses.clearAndFree(self.arena.allocator());
+        }
+
         /// Add a SELECT clause
         ///
         /// Example:


### PR DESCRIPTION
This pull request introduces a new method to the `QueryBuilder` type in `src/query.zig`, enhancing its usability by allowing queries to be reset and reused.

QueryBuilder API enhancement:

* Added a `reset` method to `QueryBuilder`, which clears all query clauses (`where_clauses`, `select_clauses`, `order_clauses`, `group_clauses`, `having_clauses`, `join_clauses`) and makes the builder reusable for constructing new queries.…r reusability.