### PR TITLE
fix: update QueryBuilder to use the correct type for item mapping

### DIFF
--- a/src/query.zig
+++ b/src/query.zig
@@ -4,6 +4,7 @@ const pg = @import("pg");
 
 /// Query builder for BaseModel operations
 pub fn QueryBuilder(comptime T: type, comptime K: type, comptime FE: type) type {
+    _ = K;
     if (!@hasDecl(T, "tableName")) {
         @compileError("Struct must have a tableName field");
     }
@@ -890,10 +891,10 @@ pub fn QueryBuilder(comptime T: type, comptime K: type, comptime FE: type) type 
             });
             defer result.deinit();
 
-            var items = std.ArrayList(K){};
+            var items = std.ArrayList(T){};
             errdefer items.deinit(allocator);
 
-            var mapper = result.mapper(K, .{ .allocator = allocator });
+            var mapper = result.mapper(T, .{ .allocator = allocator });
             while (try mapper.next()) |item| {
                 try items.append(allocator, item);
             }
@@ -977,7 +978,7 @@ pub fn QueryBuilder(comptime T: type, comptime K: type, comptime FE: type) type 
             });
             defer result.deinit();
 
-            var mapper = result.mapper(K, .{ .allocator = allocator });
+            var mapper = result.mapper(T, .{ .allocator = allocator });
             if (try mapper.next()) |item| {
                 return item;
             }


### PR DESCRIPTION
This pull request updates the `QueryBuilder` generic type in `src/query.zig` to improve type consistency and simplify the query result mapping logic. The main change is to ensure that query results are always mapped to the model type `T`, rather than a separate key type `K`. This helps prevent type mismatches and makes the code easier to reason about.

Query result mapping improvements:

* Changed the type for items in query result lists from `K` to `T` to ensure results are always mapped to the model type.
* Updated the mapper type used for query results from `K` to `T` for both single and multiple result queries. [[1]](diffhunk://#diff-64bc7312f29a9255f6914df62d35e57f0c1a3ff7c9e0aec882bf21e2fe128e39L893-R897) [[2]](diffhunk://#diff-64bc7312f29a9255f6914df62d35e57f0c1a3ff7c9e0aec882bf21e2fe128e39L980-R981)

Code simplification:

* Added an unused discard for `K` in the `QueryBuilder` function to avoid unused parameter warnings.