### PR TITLE
Add timestamps and softDelete helpers

### DIFF
--- a/src/table.zig
+++ b/src/table.zig
@@ -325,6 +325,54 @@ pub fn dateTime(self: *TableSchema, field: FieldInput) void {
     };
 }
 
+/// Adds standard created_at and updated_at timestamp fields to the table schema.
+pub fn timestamps(self: *TableSchema) void {
+    if (self.err != null) return;
+    self.fields.append(self.allocator, .{
+        .name = "created_at",
+        .type = .timestamp,
+        .not_null = true,
+        .create_input = .excluded,
+        .update_input = false,
+        .redacted = false,
+        .default_value = "CURRENT_TIMESTAMP",
+        .auto_generated = true,
+        .auto_generate_type = .timestamp,
+    }) catch |err| {
+        self.err = err;
+    };
+    self.fields.append(self.allocator, .{
+        .name = "updated_at",
+        .type = .timestamp,
+        .not_null = true,
+        .create_input = .excluded,
+        .update_input = false,
+        .redacted = false,
+        .default_value = "CURRENT_TIMESTAMP",
+        .auto_generated = true,
+        .auto_generate_type = .timestamp,
+    }) catch |err| {
+        self.err = err;
+    };
+}
+
+pub fn softDelete(self: *TableSchema) void {
+    if (self.err != null) return;
+    self.fields.append(self.allocator, .{
+        .name = "deleted_at",
+        .type = .timestamp_optional,
+        .not_null = false,
+        .create_input = .excluded,
+        .update_input = false,
+        .redacted = false,
+        .default_value = "CURRENT_TIMESTAMP",
+        .auto_generated = true,
+        .auto_generate_type = .timestamp,
+    }) catch |err| {
+        self.err = err;
+    };
+}
+
 pub fn float(self: *TableSchema, field: FieldInput) void {
     if (self.err != null) return;
     self.fields.append(self.allocator, .{

--- a/test_proj/migrations/1765179359_posts_alter_column_deleted_at.sql
+++ b/test_proj/migrations/1765179359_posts_alter_column_deleted_at.sql
@@ -1,0 +1,5 @@
+-- Migration: posts_alter_column_deleted_at
+-- Table: posts
+-- Type: alter_column
+
+ALTER TABLE posts ALTER COLUMN deleted_at SET DEFAULT CURRENT_TIMESTAMP;

--- a/test_proj/migrations/1765179359_posts_alter_column_deleted_at_down.sql
+++ b/test_proj/migrations/1765179359_posts_alter_column_deleted_at_down.sql
@@ -1,0 +1,2 @@
+-- Rollback: posts_alter_column_deleted_at
+

--- a/test_proj/schemas/.fluent_snapshot.json
+++ b/test_proj/schemas/.fluent_snapshot.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "created_at": 1765146706,
+  "created_at": 1765179470,
   "tables": [
     {
       "name": "users",
@@ -222,8 +222,8 @@
           "primary_key": false,
           "unique": false,
           "not_null": false,
-          "default_value": null,
-          "auto_generated": false,
+          "default_value": "CURRENT_TIMESTAMP",
+          "auto_generated": true,
           "auto_generate_type": "timestamp"
         }
       ],

--- a/test_proj/schemas/01_users.zig
+++ b/test_proj/schemas/01_users.zig
@@ -62,6 +62,7 @@ pub fn build(t: *TableSchema) void {
         .create_input = .excluded,
         .default_value = "CURRENT_TIMESTAMP",
         .auto_generated = true,
+        .update_input = false,
     });
 
     // Soft delete support

--- a/test_proj/schemas/02_posts.zig
+++ b/test_proj/schemas/02_posts.zig
@@ -49,29 +49,10 @@ pub fn build(t: *TableSchema) void {
     });
 
     // Timestamps - auto-generated
-    t.dateTime(.{
-        .name = "created_at",
-        .create_input = .excluded,
-        .update_input = false,
-        .default_value = "CURRENT_TIMESTAMP",
-        .auto_generated = true,
-    });
-
-    t.dateTime(.{
-        .name = "updated_at",
-        .create_input = .excluded,
-        .update_input = false,
-        .default_value = "CURRENT_TIMESTAMP",
-        .auto_generated = true,
-    });
+    t.timestamps();
 
     // Soft delete support
-    t.dateTime(.{
-        .name = "deleted_at",
-        .not_null = false,
-        .create_input = .excluded,
-        .update_input = false,
-    });
+    t.softDelete();
 
     // Relationship: post belongs to user (many-to-one) - using convenience method!
     t.belongsTo(.{

--- a/test_proj/src/models/generated/comments.zig
+++ b/test_proj/src/models/generated/comments.zig
@@ -146,10 +146,6 @@ deleted_at: ?i64,
 
     pub const updateAndReturn = base.updateAndReturn;
 
-    pub const upsert = base.upsert;
-
-    pub const upsertAndReturn = base.upsertAndReturn;
-
     pub const softDelete = base.softDelete;
 
     pub const hardDelete = base.hardDelete;

--- a/test_proj/src/models/generated/post_categories.zig
+++ b/test_proj/src/models/generated/post_categories.zig
@@ -105,10 +105,6 @@ created_at: i64,
 
     pub const updateAndReturn = base.updateAndReturn;
 
-    pub const upsert = base.upsert;
-
-    pub const upsertAndReturn = base.upsertAndReturn;
-
     pub const softDelete = base.softDelete;
 
     pub const hardDelete = base.hardDelete;

--- a/test_proj/src/models/generated/posts.zig
+++ b/test_proj/src/models/generated/posts.zig
@@ -90,7 +90,8 @@ deleted_at: ?i64,
             \\    content = COALESCE($3, content),
             \\    user_id = COALESCE($4, user_id),
             \\    is_published = COALESCE($5, is_published),
-            \\    view_count = COALESCE($6, view_count)
+            \\    view_count = COALESCE($6, view_count),
+            \\    updated_at =  CURRENT_TIMESTAMP
             \\WHERE id = $1
         ;
     }
@@ -132,10 +133,6 @@ deleted_at: ?i64,
     pub const update = base.update;
 
     pub const updateAndReturn = base.updateAndReturn;
-
-    pub const upsert = base.upsert;
-
-    pub const upsertAndReturn = base.upsertAndReturn;
 
     pub const softDelete = base.softDelete;
 

--- a/test_proj/src/models/generated/users.zig
+++ b/test_proj/src/models/generated/users.zig
@@ -60,7 +60,6 @@ bio: ?[]const u8,
         bid: ?[]const u8 = null,
         password_hash: ?[]const u8 = null,
         is_active: ?bool = null,
-        updated_at: ?i64 = null,
         phone: ?[]const u8 = null,
         bio: ?[]const u8 = null,
     };
@@ -107,9 +106,9 @@ bio: ?[]const u8,
             \\    bid = COALESCE($4, bid),
             \\    password_hash = COALESCE($5, password_hash),
             \\    is_active = COALESCE($6, is_active),
-            \\    updated_at = COALESCE($7, updated_at),
-            \\    phone = COALESCE($8, phone),
-            \\    bio = COALESCE($9, bio)
+            \\    updated_at =  CURRENT_TIMESTAMP,
+            \\    phone = COALESCE($7, phone),
+            \\    bio = COALESCE($8, bio)
             \\WHERE id = $1
         ;
     }
@@ -121,7 +120,6 @@ bio: ?[]const u8,
         ?[]const u8,
         ?[]const u8,
         ?bool,
-        ?i64,
         ?[]const u8,
         ?[]const u8,
     } {
@@ -132,7 +130,6 @@ bio: ?[]const u8,
             data.bid,
             data.password_hash,
             data.is_active,
-            data.updated_at,
             data.phone,
             data.bio,
         };


### PR DESCRIPTION
Auto-set updated_at = CURRENT_TIMESTAMP in generated UPDATE when an updated_at timestamp field exists and is excluded from update input. Return whether upsert SQL was generated and only export upsert CRUD wrappers when applicable. Add convenience timestamps()/softDelete() helpers, update schemas and snapshot, and add a migration to alter posts.deleted_at default to CURRENT_TIMESTAMP.