### PR TITLE
Remove trailing commas from uuid_optional output

### DIFF
--- a/src/model_generator.zig
+++ b/src/model_generator.zig
@@ -766,7 +766,7 @@ fn generateJsonResponseHelpers(writer: anytype, struct_name: []const u8, fields:
         if (field.type == .uuid) {
             try writer.print("try pg.uuidToHex(&self.{s}[0..16].*)", .{field.name});
         } else if (field.type == .uuid_optional) {
-            try writer.print("if (self.{s}) |id| try pg.uuidToHex(&id[0..16].*) else null,", .{field.name});
+            try writer.print("if (self.{s}) |id| try pg.uuidToHex(&id[0..16].*) else null", .{field.name});
         } else {
             try writer.print("self.{s}", .{field.name});
         }
@@ -815,7 +815,7 @@ fn generateJsonResponseHelpers(writer: anytype, struct_name: []const u8, fields:
         if (field.type == .uuid) {
             try writer.print("try pg.uuidToHex(&self.{s}[0..16].*)", .{field.name});
         } else if (field.type == .uuid_optional) {
-            try writer.print("if (self.{s}) |id| try pg.uuidToHex(&id[0..16].*) else null,", .{field.name});
+            try writer.print("if (self.{s}) |id| try pg.uuidToHex(&id[0..16].*) else null", .{field.name});
         } else {
             try writer.print("self.{s}", .{field.name});
         }


### PR DESCRIPTION
This pull request makes a minor update to the JSON response helper generation logic in `src/model_generator.zig`. The change removes an unnecessary trailing comma in the generated code for optional UUID fields, ensuring cleaner output.