### PR TITLE
Write optional UUIDs as ?[36]u8

### DIFF
--- a/src/model_generator.zig
+++ b/src/model_generator.zig
@@ -740,8 +740,10 @@ fn generateJsonResponseHelpers(writer: anytype, struct_name: []const u8, fields:
         try writer.print("{s}: ", .{field.name});
 
         // Convert UUID fields to [36]u8 hex strings
-        if (field.type == .uuid or field.type == .uuid_optional) {
+        if (field.type == .uuid) {
             try writer.writeAll("[36]u8");
+        } else if (field.type == .uuid_optional) {
+            try writer.writeAll("?[36]u8");
         } else {
             // Keep the same type for non-UUID fields
             const zig_type = field.type.toZigType();
@@ -787,8 +789,10 @@ fn generateJsonResponseHelpers(writer: anytype, struct_name: []const u8, fields:
         try writer.print("{s}: ", .{field.name});
 
         // Convert UUID fields to [36]u8 hex strings
-        if (field.type == .uuid or field.type == .uuid_optional) {
+        if (field.type == .uuid) {
             try writer.writeAll("[36]u8");
+        } else if (field.type == .uuid_optional) {
+            try writer.writeAll("?[36]u8");
         } else {
             // Keep the same type for non-UUID fields
             const zig_type = field.type.toZigType();


### PR DESCRIPTION
This pull request makes a small adjustment to how UUID fields are handled in the generated JSON response helpers. Specifically, it improves type accuracy for optional UUID fields.

* UUID fields are now written as `[36]u8` and optional UUID fields as `?[36]u8` in the generated code, instead of treating both as `[36]u8`. [[1]](diffhunk://#diff-51bea0db280920ef1a095585f7d87509dc2e529e89958f71e213b1d67150e103L743-R746) [[2]](diffhunk://#diff-51bea0db280920ef1a095585f7d87509dc2e529e89958f71e213b1d67150e103L790-R795)