### PR TITLE
Add skip-migrations and migrations-dir options

### DIFF
--- a/test_proj/schemas/runner.zig
+++ b/test_proj/schemas/runner.zig
@@ -1,10 +1,12 @@
 const std = @import("std");
-const registry = @import("registry.zig");
+
 const fluentorm = @import("fluentorm");
 const sql_generator = fluentorm.sql_generator;
 const model_generator = fluentorm.model_generator;
 const snapshot = fluentorm.snapshot;
 const diff = fluentorm.diff;
+
+const registry = @import("registry.zig");
 
 pub fn main() !void {
     var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
@@ -47,7 +49,7 @@ pub fn main() !void {
                 allocator.free(generated_files);
             }
 
-            std.debug.print("Generated {d} migration file(s):\n", .{generated_files.len});
+            std.debug.print("Generated{d} migration file(s):\n", .{generated_files.len});
             for (generated_files) |f| {
                 std.debug.print("  - {s}\n", .{f});
             }

--- a/test_proj/src/models/generated/profiles/query.zig
+++ b/test_proj/src/models/generated/profiles/query.zig
@@ -4,119 +4,119 @@
 // To regenerate: zig run scripts/generate_model.zig -- profiles.zig
 
 const std = @import("std");
-
 const pg = @import("pg");
-
 const BaseModel = @import("../base.zig").BaseModel;
-const Relationship = @import("../base.zig").Relationship;
-const err = @import("../error.zig");
-const OrmError = err.OrmError;
 const Executor = @import("../executor.zig").Executor;
 const query = @import("../query.zig");
 const JoinClause = query.JoinClause;
 const WhereValue = query.WhereValue;
+const IncludeClauseInput = Model.IncludeClauseInput;
 const Operator = query.Operator;
 const WhereClauseType = query.WhereClauseType;
 const WhereClauseInternal = query.WhereClauseInternal;
 const InType = query.InType;
 const JoinType = query.JoinType;
 const AggregateType = query.AggregateType;
-const Transaction = @import("../transaction.zig").Transaction;
-const Users = @import("../users/model.zig");
 const Model = @import("model.zig");
 const FieldEnum = Model.FieldEnum;
 const RelationEnum = Model.RelationEnum;
-const IncludeClauseInput = Model.IncludeClauseInput;
+const Transaction = @import("../transaction.zig").Transaction;
+const Relationship = @import("../base.zig").Relationship;
+const err = @import("../error.zig");
+const OrmError = err.OrmError;
 
 // Related models
+const Users = @import("../users/model.zig");
+
 const Self = @This();
 
 // Fields
-arena: std.heap.ArenaAllocator,
-select_clauses: std.ArrayList([]const u8),
-where_clauses: std.ArrayList(WhereClauseInternal),
-order_clauses: std.ArrayList([]const u8),
-group_clauses: std.ArrayList([]const u8),
-having_clauses: std.ArrayList([]const u8),
-join_clauses: std.ArrayList(JoinClause),
-limit_val: ?u64 = null,
-offset_val: ?u64 = null,
-include_deleted: bool = false,
-distinct_enabled: bool = false,
-includes_clauses: std.ArrayList(Model.IncludeClauseInput),
-base_select_custom: bool = false,
-select_raw: bool = false,
-fill_base_select: bool = false,
-owns_arena: bool = true,
+ arena: std.heap.ArenaAllocator,
+ select_clauses: std.ArrayList([]const u8),
+ where_clauses: std.ArrayList(WhereClauseInternal),
+ order_clauses: std.ArrayList([]const u8),
+ group_clauses: std.ArrayList([]const u8),
+ having_clauses: std.ArrayList([]const u8),
+ join_clauses: std.ArrayList(JoinClause),
+ limit_val: ?u64 = null,
+ offset_val: ?u64 = null,
+ include_deleted: bool = false,
+ distinct_enabled: bool = false,
+ includes_clauses: std.ArrayList(Model.IncludeClauseInput),
+ base_select_custom: bool = false,
+ select_raw: bool = false,
+ fill_base_select: bool = false,
+ owns_arena: bool = true,
 
-pub const WhereClause = struct {
-    where_type: WhereClauseType = .@"and",
-    field: FieldEnum,
-    operator: Operator,
-    value: ?WhereValue = null,
-};
+  pub const WhereClause = struct {
+      where_type: WhereClauseType = .@"and",
+      field: FieldEnum,
+      operator: Operator,
+      value: ?WhereValue = null,
+   };
 
-pub const OrderByClause = struct {
-    field: FieldEnum,
-    direction: enum {
-        asc,
-        desc,
-    },
-    pub fn toSql(self: OrderByClause) []const u8 {
-        return switch (self.direction) {
+
+ pub const OrderByClause = struct {
+      field: FieldEnum,
+      direction: enum {
+         asc,
+         desc,
+      },
+     pub fn toSql(self: OrderByClause) []const u8 {
+         return switch (self.direction) {
             .asc => "ASC",
             .desc => "DESC",
-        };
-    }
-};
+         };
+      }
+   };
 
-pub const SelectField = []const FieldEnum;
-pub fn tablename(_: *Self) []const u8 {
+   pub const SelectField = []const FieldEnum;
+ pub fn tablename(_: *Self) []const u8 {
     return Model.tableName();
-}
+ }
 
-/// Create a new query builder using page_allocator for its arena.
-pub fn init() Self {
+ /// Create a new query builder using page_allocator for its arena.
+ pub fn init() Self {
     return initWithAllocator(std.heap.page_allocator);
-}
+ }
 
-/// Create a query builder with a custom backing allocator for its arena.
-pub fn initWithAllocator(backing_allocator: std.mem.Allocator) Self {
+ /// Create a query builder with a custom backing allocator for its arena.
+ pub fn initWithAllocator(backing_allocator: std.mem.Allocator) Self {
     return Self{
-        .arena = std.heap.ArenaAllocator.init(backing_allocator),
-        .select_clauses = std.ArrayList([]const u8){},
-        .where_clauses = std.ArrayList(WhereClauseInternal){},
-        .order_clauses = std.ArrayList([]const u8){},
-        .group_clauses = std.ArrayList([]const u8){},
-        .having_clauses = std.ArrayList([]const u8){},
-        .join_clauses = std.ArrayList(JoinClause){},
-        .includes_clauses = std.ArrayList(Model.IncludeClauseInput){},
-        .base_select_custom = false,
-        .select_raw = false,
-        .fill_base_select = false,
+       .arena = std.heap.ArenaAllocator.init(backing_allocator),
+       .select_clauses = std.ArrayList([]const u8){},
+       .where_clauses = std.ArrayList(WhereClauseInternal){},
+       .order_clauses = std.ArrayList([]const u8){},
+       .group_clauses = std.ArrayList([]const u8){},
+       .having_clauses = std.ArrayList([]const u8){},
+       .join_clauses = std.ArrayList(JoinClause){},
+       .includes_clauses = std.ArrayList(Model.IncludeClauseInput){},
+       .base_select_custom = false,
+       .select_raw = false,
+       .fill_base_select = false,
     };
-}
+ }
 
-/// Create a query builder using an existing ArenaAllocator.
-/// Ideal for http.zig request handlers where the arena is managed externally.
-pub fn initWithArena(arena_allocator: *std.heap.ArenaAllocator) Self {
+ /// Create a query builder using an existing ArenaAllocator.
+ /// Ideal for http.zig request handlers where the arena is managed externally.
+ pub fn initWithArena(arena_allocator: *std.heap.ArenaAllocator) Self {
     return Self{
-        .arena = arena_allocator.*,
-        .owns_arena = false,
-        .select_clauses = std.ArrayList([]const u8){},
-        .where_clauses = std.ArrayList(WhereClauseInternal){},
-        .order_clauses = std.ArrayList([]const u8){},
-        .group_clauses = std.ArrayList([]const u8){},
-        .having_clauses = std.ArrayList([]const u8){},
-        .join_clauses = std.ArrayList(JoinClause){},
-        .includes_clauses = std.ArrayList(Model.IncludeClauseInput){},
-        .base_select_custom = false,
-        .select_raw = false,
-        .fill_base_select = false,
+       .arena = arena_allocator.*,
+       .owns_arena = false,
+       .select_clauses = std.ArrayList([]const u8){},
+       .where_clauses = std.ArrayList(WhereClauseInternal){},
+       .order_clauses = std.ArrayList([]const u8){},
+       .group_clauses = std.ArrayList([]const u8){},
+       .having_clauses = std.ArrayList([]const u8){},
+       .join_clauses = std.ArrayList(JoinClause){},
+       .includes_clauses = std.ArrayList(Model.IncludeClauseInput){},
+       .base_select_custom = false,
+       .select_raw = false,
+       .fill_base_select = false,
     };
-}
+ }
 
-pub fn deinit(self: *Self) void {
+ pub fn deinit(self: *Self) void {
     self.where_clauses.deinit(self.arena.allocator());
     self.select_clauses.deinit(self.arena.allocator());
     self.order_clauses.deinit(self.arena.allocator());
@@ -127,9 +127,9 @@ pub fn deinit(self: *Self) void {
     if (self.owns_arena) {
         self.arena.deinit();
     }
-}
+ }
 
-pub fn reset(self: *Self) void {
+ pub fn reset(self: *Self) void {
     self.select_clauses.clearAndFree(self.arena.allocator());
     self.where_clauses.clearAndFree(self.arena.allocator());
     self.order_clauses.clearAndFree(self.arena.allocator());
@@ -144,46 +144,45 @@ pub fn reset(self: *Self) void {
     self.base_select_custom = false;
     self.select_raw = false;
     self.fill_base_select = false;
-}
-pub fn buildIncludeSql(self: *Self, rel: IncludeClauseInput) !JoinClause {
-    const rel_tag = std.meta.activeTag(rel);
-    const relation = Model.getRelation(rel_tag);
-    var clause = JoinClause{
-        .join_type = JoinType.left,
-        .join_table = relation.foreign_table,
-        .join_field = relation.foreign_key,
-        .join_operator = .eq,
-        .base_field = relation.local_key,
-        .predicates = &.{},
-        .select = &.{"*"},
-    };
+ }
+    pub fn buildIncludeSql(self: *Self, rel: IncludeClauseInput) !JoinClause {
+        const rel_tag = std.meta.activeTag(rel);
+        const relation = Model.getRelation(rel_tag);
+        var clause = JoinClause{
+            .join_type = JoinType.left,
+           .join_table = relation.foreign_table,
+           .join_field = relation.foreign_key,
+           .join_operator = .eq,
+          .base_field = relation.local_key,
+           .predicates = &.{},
+           .select = &.{"*"},
+       };
 
-    switch (rel) {
-        .user => |r| {
-            // Construct the where clause from rel into an sql string
-            if (r.where.len > 0) {
-                clause.predicates = try self.arena.allocator().alloc(query.PredicateClause, r.where.len);
-                for (r.where, 0..) |cl, i| {
-                    const str = try query.buildIncludeWhere(self, cl, @tagName(relation.foreign_table), cl.value);
-                    clause.predicates[i] = .{
-                        .where_type = cl.where_type,
-                        .sql = str,
-                    };
+        switch (rel) {            .user => |r| {
+                // Construct the where clause from rel into an sql string
+                if (r.where.len > 0) {
+                    clause.predicates = try self.arena.allocator().alloc(query.PredicateClause, r.where.len);
+                    for (r.where, 0..) |cl, i| {
+                        const str = try query.buildIncludeWhere(self, cl, @tagName(relation.foreign_table), cl.value);
+                        clause.predicates[i] = .{
+                            .where_type = cl.where_type,
+                            .sql = str,
+                        };
+                    }
                 }
-            }
 
-            // Construct select clause
-            if (r.select.len > 0) {
-                const selects = try self.arena.allocator().alloc([]const u8, r.select.len);
-                for (r.select, 0..) |field, i| {
-                    selects[i] = @tagName(field);
+                // Construct select clause
+                if (r.select.len > 0) {
+                    const selects = try self.arena.allocator().alloc([]const u8, r.select.len);
+                    for (r.select, 0..) |field, i| {
+                        selects[i] = @tagName(field);
+                    }
+                    clause.select = selects;
                 }
-                clause.select = selects;
-            }
-        },
+            },
+        }
+        return clause;
     }
-    return clause;
-}
 /// Add a SELECT clause
 ///
 /// Example:
@@ -394,6 +393,7 @@ pub fn join(self: *Self, comptime join_clause: JoinClause) *Self {
     return self;
 }
 
+
 /// Add GROUP BY clause
 ///
 /// Example:
@@ -576,31 +576,19 @@ pub fn buildSql(self: *Self, allocator: std.mem.Allocator) ![]const u8 {
                         const next_is_or = (i < join_clause.predicates.len - 1 and join_clause.predicates[i + 1].where_type == .@"or");
                         if (i == 0) {
                             try sql.appendSlice(allocator, " AND ");
-                            if (next_is_or) {
-                                try sql.appendSlice(allocator, "(");
-                                in_or_group = true;
-                            }
+                            if (next_is_or) { try sql.appendSlice(allocator, "("); in_or_group = true; }
                             try sql.appendSlice(allocator, predicate.sql);
                             continue;
                         }
                         if (predicate.where_type == .@"and") {
-                            if (in_or_group) {
-                                try sql.appendSlice(allocator, ")");
-                                in_or_group = false;
-                            }
+                            if (in_or_group) { try sql.appendSlice(allocator, ")"); in_or_group = false; }
                             try sql.appendSlice(allocator, " AND ");
-                            if (next_is_or) {
-                                try sql.appendSlice(allocator, "(");
-                                in_or_group = true;
-                            }
+                            if (next_is_or) { try sql.appendSlice(allocator, "("); in_or_group = true; }
                             try sql.appendSlice(allocator, predicate.sql);
                         } else {
                             try sql.appendSlice(allocator, " OR ");
                             try sql.appendSlice(allocator, predicate.sql);
-                            if (!next_is_or and in_or_group) {
-                                try sql.appendSlice(allocator, ")");
-                                in_or_group = false;
-                            }
+                            if (!next_is_or and in_or_group) { try sql.appendSlice(allocator, ")"); in_or_group = false; }
                         }
                     }
                     if (in_or_group) try sql.appendSlice(allocator, ")");
@@ -642,7 +630,7 @@ pub fn buildSql(self: *Self, allocator: std.mem.Allocator) ![]const u8 {
             }
         }
     } else {
-        if (!has_select_clause) {
+         if (!has_select_clause) {
             try sql.writer(allocator).print("{s}.*", .{table_name});
         }
     }
@@ -886,6 +874,7 @@ pub fn fetch(self: *Self, db: Executor, allocator: std.mem.Allocator, args: anyt
     }
 }
 
+
 /// Execute query and return list of items mapped to a custom result type.
 /// Use this when you have custom selects, aggregates, or need a difFieldEnumrent shape than the model.
 ///
@@ -942,7 +931,7 @@ pub fn fetchRaw(self: *Self, db: Executor, args: anytype) !pg.Result {
 /// // results[0].posts is now parsed from JSONB!
 /// ```
 pub fn fetchWithRel(self: *Self, comptime R: type, db: Executor, allocator: std.mem.Allocator, args: anytype) err.Result([]R) {
-    comptime {
+     comptime {
         if (!@hasDecl(R, "fromRow")) {
             @compileError("R must have fromRow method");
         }
@@ -1021,7 +1010,7 @@ pub fn firstAs(self: *Self, comptime R: type, db: Executor, allocator: std.mem.A
 /// // user.?.posts is now parsed from JSONB!
 /// ```
 pub fn firstWithRel(self: *Self, comptime R: type, db: Executor, allocator: std.mem.Allocator, args: anytype) err.Result(?R) {
-    comptime {
+     comptime {
         if (!@hasDecl(R, "fromRow")) {
             @compileError("R must have fromRow method");
         }


### PR DESCRIPTION
This pull request introduces an option to skip SQL migration generation throughout the build and code generation process, making it possible to generate only model files without producing migration scripts. The change is reflected in the build scripts, documentation, and the code generator itself. The most important changes are as follows:

**Build System and CLI Integration:**
- Added a `skip-migrations` boolean option to the build scripts (`build.zig` in examples and docs), allowing users to control whether SQL migrations are generated. If enabled, the build system passes a special flag to the generator instead of a migrations directory. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R55-R60) [[2]](diffhunk://#diff-96f9ebb9f60e0a8354a5def3958ce814d311147ca1a5d5c6ba9c36d922d9429cR52-R54) [[3]](diffhunk://#diff-a558776ce936a73b16f83d3094f9cf88413fc193a4cce3e542aedbc7dca92250R10-R12)
- Updated the generator invocation logic to append either the migrations directory or the `--skip-migrations` flag based on the new option. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R87-R91) [[2]](diffhunk://#diff-96f9ebb9f60e0a8354a5def3958ce814d311147ca1a5d5c6ba9c36d922d9429cL77-R85) [[3]](diffhunk://#diff-a558776ce936a73b16f83d3094f9cf88413fc193a4cce3e542aedbc7dca92250L66-R78)

**Code Generation Logic:**
- Enhanced `src/generate_model.zig` to detect the `--skip-migrations` flag, update usage instructions, and conditionally omit all migration-related logic and imports when skipping migrations. This includes dynamic generation of the runner source code to exclude migration handling if the flag is set. [[1]](diffhunk://#diff-86da49cab32889ee965143675c6974a298c6481041ab0759ed86a856faff8966L23-R40) [[2]](diffhunk://#diff-86da49cab32889ee965143675c6974a298c6481041ab0759ed86a856faff8966R62) [[3]](diffhunk://#diff-86da49cab32889ee965143675c6974a298c6481041ab0759ed86a856faff8966R96-R101) [[4]](diffhunk://#diff-86da49cab32889ee965143675c6974a298c6481041ab0759ed86a856faff8966L127-R212) [[5]](diffhunk://#diff-86da49cab32889ee965143675c6974a298c6481041ab0759ed86a856faff8966L183-R225)

**Documentation Updates:**
- Updated documentation in `README.md` and `docs/GETTING_STARTED.md` to describe the new `skip-migrations` option, including usage examples for generating only models. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R195-R205) [[2]](diffhunk://#diff-96f9ebb9f60e0a8354a5def3958ce814d311147ca1a5d5c6ba9c36d922d9429cR182-R191)

**Miscellaneous:**
- Minor code style and import order fix in `test_proj/schemas/runner.zig`.